### PR TITLE
feat: 메인 페이지 퍼블리싱 (Hero, Profile, Discography, Merch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "gsap": "^3.15.0",
         "next": "16.2.4",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "split-type": "^0.3.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6256,6 +6257,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/split-type": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/split-type/-/split-type-0.3.4.tgz",
+      "integrity": "sha512-otEk9vnD8qwfLsk3Lx0gz+qRkNIJCx0mlyL47ImP/DjMuV39d75Lpfwjn9fHteDRz0aoOblSzQjSNT9+Sswxcg==",
+      "license": "ISC"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "gsap": "^3.15.0",
     "next": "16.2.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "split-type": "^0.3.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/(home)/hero/hero.module.scss
+++ b/src/app/(home)/hero/hero.module.scss
@@ -1,0 +1,24 @@
+.hero {
+  &-section {
+    &__inner {
+      display: flex;
+      margin-top: 50px;
+      margin-bottom: 50px;
+      gap: 40px;
+    }
+    &__image {
+      width: clamp(300px, 39.0625vw, 1500px);
+      aspect-ratio: 750 / 937;
+      position: relative;
+    }
+    &__title {
+      line-height: 1.2;
+      cursor: default;
+
+      &-line {
+        display: block;
+        overflow: hidden;
+      }
+    }
+  }
+}

--- a/src/app/(home)/hero/index.tsx
+++ b/src/app/(home)/hero/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import gsap from "gsap";
+import SplitType from "split-type";
+import style from "./hero.module.scss";
+import Image from "next/image";
+import { Typography } from "@/src/components/common/typography";
+import { Happy } from "@/src/components/common/happy";
+import { useEffect, useRef } from "react";
+
+export const HeroSection = () => {
+  const titleRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!titleRef.current) return;
+
+    const lines =
+      titleRef.current.querySelectorAll<HTMLElement>("[data-hero-title]");
+    const split = new SplitType(Array.from(lines), { types: "chars" });
+
+    gsap.from(split.chars, {
+      y: 100,
+      opacity: 0,
+      duration: 0.8,
+      stagger: 0.06,
+      ease: "power2.out",
+    });
+  }, []);
+
+  return (
+    <section className="hero-section">
+      <Happy />
+      <div className={style["hero-section__inner"]}>
+        <div className={style["hero-section__image"]}>
+          <Image
+            src="/assets/images/band-hero.png"
+            alt="SIMILE LAND image"
+            fill
+            priority
+            sizes="39vw"
+          />
+        </div>
+
+        <div ref={titleRef}>
+          <Typography
+            weight="bold"
+            size="heading-1"
+            className={style["hero-section__title"]}
+          >
+            <span data-hero-title className={style["hero-section__title-line"]}>
+              We wanna
+            </span>
+            <span data-hero-title className={style["hero-section__title-line"]}>
+              make you
+            </span>
+            <span data-hero-title className={style["hero-section__title-line"]}>
+              smile !!
+            </span>
+          </Typography>
+        </div>
+      </div>
+      <Happy />
+    </section>
+  );
+};

--- a/src/app/(home)/hero/index.tsx
+++ b/src/app/(home)/hero/index.tsx
@@ -18,13 +18,18 @@ export const HeroSection = () => {
       titleRef.current.querySelectorAll<HTMLElement>("[data-hero-title]");
     const split = new SplitType(Array.from(lines), { types: "chars" });
 
-    gsap.from(split.chars, {
+    const tween = gsap.from(split.chars, {
       y: 100,
       opacity: 0,
       duration: 0.8,
       stagger: 0.06,
       ease: "power2.out",
     });
+
+    return () => {
+      tween.kill();
+      split.revert();
+    };
   }, []);
 
   return (

--- a/src/app/(home)/profile/index.tsx
+++ b/src/app/(home)/profile/index.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Image from "next/image";
+import style from "./profile.module.scss";
+import gsap from "gsap";
+import { useEffect, useRef, useState } from "react";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { Typography } from "@/src/components/common/typography";
+import { profileData } from "./mock-constants";
+import { SectionTitle } from "@/src/components/common/section-title";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export const Profile = () => {
+  const profileRef = useRef<HTMLElement>(null);
+  const profileCardsRef = useRef<(HTMLDivElement | null)[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const profile = profileRef.current;
+    const profileCards = profileCardsRef.current.filter(
+      (c): c is HTMLDivElement => c !== null,
+    );
+
+    if (!profile || profileCards.length === 0) return;
+
+    const ctx = gsap.context(() => {
+      const tl = gsap.timeline({
+        scrollTrigger: {
+          trigger: profile,
+          start: "top top",
+          end: `+=${(profileData.length - 1) * window.innerHeight}`,
+          pin: true,
+          scrub: 1,
+          onUpdate: (self) => {
+            const index = Math.round(self.progress * (profileData.length - 1));
+            setActiveIndex(index);
+          },
+        },
+      });
+
+      profileCards.slice(1).forEach((card, i) => {
+        tl.fromTo(
+          card,
+          { y: "100%" },
+          { y: "0%", ease: "none", duration: 1 },
+          i,
+        );
+      });
+    }, profile);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section ref={profileRef} className={style.profile}>
+      <SectionTitle>PROFILE</SectionTitle>
+
+      <div className={style["profile__cards"]}>
+        {/* TODO: 데코 요소 애니메이션 추가
+        <div ref={deco1Ref} className={style["profile__deco-1"]} />
+        <div ref={deco2Ref} className={style["profile__deco-2"]} /> */}
+        {profileData.map((member, index) => (
+          <div
+            key={`member-${index}`}
+            ref={(el) => {
+              profileCardsRef.current[index] = el;
+            }}
+            className={style["profile__card"]}
+            style={{
+              zIndex: index + 1,
+              transform: index > 0 ? "translateY(100%)" : undefined,
+            }}
+          >
+            <div className={style["profile__image"]}>
+              <Image
+                src={member.image}
+                alt={`${member.name} 프로필 이미지`}
+                fill
+                priority
+                sizes="52vw"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={style["profile__info"]}>
+        <Typography size="body" weight="medium">
+          {profileData[activeIndex].position.split("").map((char, i) => (
+            <span
+              key={i}
+              style={{
+                display: "inline-block",
+                whiteSpace: char === " " ? "pre" : undefined,
+              }}
+            >
+              {char}
+            </span>
+          ))}
+        </Typography>
+
+        <Typography size="heading-4" weight="bold">
+          {profileData[activeIndex].name.split("").map((char, i) => (
+            <span
+              key={i}
+              style={{
+                display: "inline-block",
+              }}
+            >
+              {char}
+            </span>
+          ))}
+        </Typography>
+      </div>
+    </section>
+  );
+};

--- a/src/app/(home)/profile/index.tsx
+++ b/src/app/(home)/profile/index.tsx
@@ -77,7 +77,7 @@ export const Profile = () => {
                 src={member.image}
                 alt={`${member.name} 프로필 이미지`}
                 fill
-                priority
+                preload={index === 0}
                 sizes="52vw"
               />
             </div>

--- a/src/app/(home)/profile/mock-constants.ts
+++ b/src/app/(home)/profile/mock-constants.ts
@@ -1,0 +1,27 @@
+export const profileData = [
+  {
+    image: "/assets/images/band-member-sim-ail.png",
+    name: "심아일",
+    position: "Vocal / Guitar",
+  },
+  {
+    image: "/assets/images/band-member-laffa.png",
+    name: "Laffa",
+    position: "Keyboard / Keytar",
+  },
+  {
+    image: "/assets/images/band-member-son-se-won.png",
+    name: "손세원",
+    position: "Electric Guitar",
+  },
+  {
+    image: "/assets/images/band-member-jang-su-won.png",
+    name: "장수원",
+    position: "Bass",
+  },
+  {
+    image: "/assets/images/band-member-kim-kyung-hoon.png",
+    name: "김경훈",
+    position: "Drums",
+  },
+];

--- a/src/app/(home)/profile/profile.module.scss
+++ b/src/app/(home)/profile/profile.module.scss
@@ -1,0 +1,55 @@
+.profile {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &__cards {
+    position: relative;
+    height: 100%;
+    max-height: clamp(624px, 32.5vw, 1248px);
+    overflow: hidden;
+  }
+
+  &__card {
+    position: absolute;
+    inset: 0;
+  }
+
+  &__image {
+    height: clamp(624px, 32.5vw, 1248px);
+    position: relative;
+    overflow: hidden;
+
+    img {
+      width: auto;
+      max-width: clamp(1000px, 52.0833vw, 2000px);
+      height: clamp(624px, 32.5vw, 1248px);
+    }
+  }
+
+  &__deco-1 {
+    position: absolute;
+    left: 35%;
+    right: 0;
+    top: 54%;
+    height: clamp(50px, 3.9vw, 75px);
+    background-color: var(--color-yellow);
+    z-index: 0;
+  }
+
+  &__deco-2 {
+    position: absolute;
+    left: 38%;
+    right: 0;
+    top: 65%;
+    height: clamp(30px, 2.35vw, 45px);
+    background-color: var(--color-teal);
+    z-index: 0;
+  }
+
+  &__info {
+    margin-top: 20px;
+    flex-shrink: 0;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
+import "../styles/globals.css";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import "../styles/globals.scss";
 import { Header } from "../components/layout/header";
 import { AudioProvider } from "../components/providers/audio-provider";
 import { Footer } from "../components/layout/footer";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,15 @@
+import { Profile } from "./(home)/profile";
+import { HeroSection } from "./(home)/hero";
+import { Discography } from "@/src/features/discography";
+import { Merch } from "@/src/features/merch";
+
 export default function Home() {
-  return <div className=""></div>;
+  return (
+    <main className="space-y-[250px]">
+      <HeroSection />
+      <Profile />
+      <Discography />
+      <Merch />
+    </main>
+  );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,3 +1,0 @@
-export default function Profile() {
-  return <div>프로필 페이지</div>;
-}

--- a/src/components/common/button/index.tsx
+++ b/src/components/common/button/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { ReactNode } from "react";
 import { Typography, type Weight, type Size } from "../typography";
 
@@ -11,6 +12,7 @@ type BaseButtonProps = {
   textSize?: Size;
   textWeight?: Weight;
   onClick?: () => void;
+  href?: string;
 };
 
 type EmojiButtonProps = BaseButtonProps & { variant: "emoji" };
@@ -35,33 +37,44 @@ export const Button = ({
   textSize,
   textWeight,
   onClick,
+  href,
 }: ButtonProps) => {
   if (variant === "emoji") {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={`group flex items-center gap-0 overflow-hidden rounded-full px-10 py-4 transition-all duration-300 cursor-pointer ${colorClass[bgColor]} ${className ?? ""}`}
-      >
+    const emojiClass = `group flex items-center gap-0 overflow-hidden rounded-full px-10 py-4 transition-all duration-300 cursor-pointer ${colorClass[bgColor]} ${className ?? ""}`;
+    const emojiContent = (
+      <>
         <span className="flex w-0 overflow-hidden transition-all duration-300 group-hover:mr-2 group-hover:w-6">
           <Image src="/assets/icons/smile.svg" alt="" width={20} height={20} />
         </span>
         <Typography size={textSize} weight={textWeight}>
           {children}
         </Typography>
+      </>
+    );
+
+    if (href) {
+      return <Link href={href} className={emojiClass}>{emojiContent}</Link>;
+    }
+    return (
+      <button type="button" onClick={onClick} className={emojiClass}>
+        {emojiContent}
       </button>
     );
   }
 
+  const defaultClass = `rounded-xl p-5 cursor-pointer ${colorClass[bgColor]} ${className ?? ""}`;
+  const defaultContent = (
+    <Typography size={textSize} weight={textWeight}>
+      {children}
+    </Typography>
+  );
+
+  if (href) {
+    return <Link href={href} className={defaultClass}>{defaultContent}</Link>;
+  }
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`rounded-xl p-5 cursor-pointer ${colorClass[bgColor]} ${className ?? ""}`}
-    >
-      <Typography size={textSize} weight={textWeight}>
-        {children}
-      </Typography>
+    <button type="button" onClick={onClick} className={defaultClass}>
+      {defaultContent}
     </button>
   );
 };

--- a/src/features/discography/components/discography.module.scss
+++ b/src/features/discography/components/discography.module.scss
@@ -1,0 +1,55 @@
+@import "../../../styles/_variables";
+
+.discography {
+  &__grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    column-gap: clamp(16px, 1.5vw, 28px);
+    row-gap: clamp(40px, 4vw, 60px);
+    margin-bottom: clamp(40px, 5vw, 80px);
+  }
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__image {
+    aspect-ratio: 835 / 550;
+    position: relative;
+    overflow: hidden;
+
+    img {
+      object-fit: contain;
+    }
+  }
+
+  &__image-inner {
+    position: absolute;
+    inset: -5%;
+    will-change: transform;
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding-top: clamp(16px, 1.5vw, 24px);
+    text-align: center;
+  }
+
+  &__title {
+    color: $color-blue;
+  }
+
+  &__date,
+  &__desc {
+    color: $color-ink;
+  }
+
+  &__cta {
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/src/features/discography/components/discography.module.scss
+++ b/src/features/discography/components/discography.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/_variables";
+@import "../../../styles/variables";
 
 .discography {
   &__grid {

--- a/src/features/discography/components/discography.tsx
+++ b/src/features/discography/components/discography.tsx
@@ -110,6 +110,7 @@ export const Discography = () => {
           className={style["discography__cta-btn"]}
           textSize="body"
           textWeight="semibold"
+          href="/discography"
         >
           SEE ALL DISCOGRAPHY
         </Button>

--- a/src/features/discography/components/discography.tsx
+++ b/src/features/discography/components/discography.tsx
@@ -3,7 +3,7 @@
 import gsap from "gsap";
 import Image from "next/image";
 import style from "./discography.module.scss";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Typography } from "@/src/components/common/typography";
 import { Button } from "@/src/components/common/button";
 import { extractEdgeColors } from "@/src/features/discography/utils/extractColor";
@@ -16,6 +16,13 @@ const DiscographyCard = ({ image, title, date, description }: CardProps) => {
   const [gradient, setGradient] = useState<string | null>(null);
   const imageRef = useRef<HTMLDivElement>(null);
   const TILT_MAX = 12;
+
+  useEffect(() => {
+    const el = imageRef.current;
+    return () => {
+      gsap.killTweensOf(el);
+    };
+  }, []);
 
   const handleLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
     try {

--- a/src/features/discography/components/discography.tsx
+++ b/src/features/discography/components/discography.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import gsap from "gsap";
+import Image from "next/image";
+import style from "./discography.module.scss";
+import { useState, useRef } from "react";
+import { Typography } from "@/src/components/common/typography";
+import { Button } from "@/src/components/common/button";
+import { extractEdgeColors } from "@/src/features/discography/utils/extractColor";
+import { SectionTitle } from "@/src/components/common/section-title";
+import { discographyData } from "../constants";
+
+type CardProps = (typeof discographyData)[number];
+
+const DiscographyCard = ({ image, title, date, description }: CardProps) => {
+  const [gradient, setGradient] = useState<string | null>(null);
+  const imageRef = useRef<HTMLDivElement>(null);
+  const TILT_MAX = 12;
+
+  const handleLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    try {
+      const [left, right] = extractEdgeColors(e.currentTarget);
+      setGradient(`linear-gradient(to right, ${left}, ${right})`);
+    } catch {
+      // 캔버스 추출 실패 시 gradient 미적용
+    }
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const image = imageRef.current;
+    if (!image) return;
+    const { left, top, width, height } =
+      e.currentTarget.getBoundingClientRect();
+    const x = (e.clientX - left) / width - 0.5;
+    const y = (e.clientY - top) / height - 0.5;
+    gsap.to(image, {
+      rotateY: x * TILT_MAX * 1.2,
+      rotateX: -y * TILT_MAX * 1.2,
+      scale: 1.05,
+      duration: 0.7,
+      ease: "power2.out",
+      transformPerspective: 800,
+    });
+  };
+
+  const handleMouseLeave = () => {
+    gsap.to(imageRef.current, {
+      x: 0,
+      y: 0,
+      rotateY: 0,
+      rotateX: 0,
+      scale: 1,
+      duration: 0.7,
+      ease: "power3.out",
+    });
+  };
+
+  return (
+    <div className={style["discography__card"]}>
+      <div
+        className={style["discography__image"]}
+        style={gradient ? { background: gradient } : undefined}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+      >
+        <div ref={imageRef} className={style["discography__image-inner"]}>
+          <Image
+            src={image}
+            alt={`${title} 앨범 이미지`}
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            onLoad={handleLoad}
+          />
+        </div>
+      </div>
+      <div className={style["discography__info"]}>
+        <Typography
+          size="heading-5"
+          weight="bold"
+          className={style["discography__title"]}
+        >
+          {title}
+        </Typography>
+        <Typography size="body" className={style["discography__date"]}>
+          {date}
+        </Typography>
+        <Typography size="body" className={style["discography__desc"]}>
+          {description}
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+export const Discography = () => {
+  return (
+    <section className={style.discography}>
+      <SectionTitle>DISCOGRAPHY</SectionTitle>
+
+      <div className={style["discography__grid"]}>
+        {discographyData.slice(0, 4).map((album, index) => (
+          <DiscographyCard key={index} {...album} />
+        ))}
+      </div>
+
+      <div className={style["discography__cta"]}>
+        <Button
+          variant="emoji"
+          bgColor="teal"
+          className={style["discography__cta-btn"]}
+          textSize="body"
+          textWeight="semibold"
+        >
+          SEE ALL DISCOGRAPHY
+        </Button>
+      </div>
+    </section>
+  );
+};

--- a/src/features/discography/constants/index.ts
+++ b/src/features/discography/constants/index.ts
@@ -1,0 +1,27 @@
+export const discographyData = [
+  {
+    image: "/assets/images/discography-ohwah.png",
+    title: "OhWah!",
+    date: "2026.04.23",
+    description: "우리는 어디에서 왔고, 어디로 가고 있을까?",
+  },
+  {
+    image: "/assets/images/discography-young-hee.png",
+    title: "Young-Hee",
+    date: "2025.10.30",
+    description: "심아일랜드가 그리는 보편의 우울",
+  },
+  {
+    image: "/assets/images/discography-worriors.png",
+    title: "Worriors",
+    date: "2025.04.29",
+    description:
+      "Worriors는 Worry와 Warriors의 합성어로 걱정하는 자들 이라는 의미를 담고 있다.",
+  },
+  {
+    image: "/assets/images/discography-cheol-su.png",
+    title: "Cheol-Su",
+    date: "2024.08.19",
+    description: "신나는 음악을 좋아하는 'Cheol-Su'는 도파민 중독자다.",
+  },
+];

--- a/src/features/discography/index.ts
+++ b/src/features/discography/index.ts
@@ -1,0 +1,1 @@
+export * from "./components/discography";

--- a/src/features/discography/utils/extractColor.ts
+++ b/src/features/discography/utils/extractColor.ts
@@ -25,7 +25,13 @@ export const extractEdgeColors = (img: HTMLImageElement): [string, string] => {
     return `rgb(${Math.round(r / pixelCount)},${Math.round(g / pixelCount)},${Math.round(b / pixelCount)})`;
   };
 
-  const leftColor = avgRgb(ctx.getImageData(0, 0, sampleW, h).data);
-  const rightColor = avgRgb(ctx.getImageData(w - sampleW, 0, sampleW, h).data);
-  return [leftColor, rightColor];
+  try {
+    const leftColor = avgRgb(ctx.getImageData(0, 0, sampleW, h).data);
+    const rightColor = avgRgb(
+      ctx.getImageData(w - sampleW, 0, sampleW, h).data,
+    );
+    return [leftColor, rightColor];
+  } catch {
+    return ["transparent", "transparent"];
+  }
 };

--- a/src/features/discography/utils/extractColor.ts
+++ b/src/features/discography/utils/extractColor.ts
@@ -1,0 +1,31 @@
+export const extractEdgeColors = (img: HTMLImageElement): [string, string] => {
+  const { naturalWidth: w, naturalHeight: h } = img;
+  if (!w || !h) return ["transparent", "transparent"];
+
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return ["transparent", "transparent"];
+
+  canvas.width = w;
+  canvas.height = h;
+  ctx.drawImage(img, 0, 0);
+
+  const sampleW = Math.max(1, Math.floor(w * 0.15));
+  const pixelCount = sampleW * h;
+
+  const avgRgb = (data: Uint8ClampedArray) => {
+    let r = 0,
+      g = 0,
+      b = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      r += data[i];
+      g += data[i + 1];
+      b += data[i + 2];
+    }
+    return `rgb(${Math.round(r / pixelCount)},${Math.round(g / pixelCount)},${Math.round(b / pixelCount)})`;
+  };
+
+  const leftColor = avgRgb(ctx.getImageData(0, 0, sampleW, h).data);
+  const rightColor = avgRgb(ctx.getImageData(w - sampleW, 0, sampleW, h).data);
+  return [leftColor, rightColor];
+};

--- a/src/features/merch/components/merch.module.scss
+++ b/src/features/merch/components/merch.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/_variables";
+@import "../../../styles/variables";
 
 .merch {
   &__grid {
@@ -36,11 +36,7 @@
     top: 30px;
     right: 30px;
     z-index: 10;
-    background: none;
-    border: none;
     cursor: pointer;
-    padding: 0;
-    line-height: 0;
   }
 
   &__like-icon--inactive {

--- a/src/features/merch/components/merch.module.scss
+++ b/src/features/merch/components/merch.module.scss
@@ -1,0 +1,68 @@
+@import "../../../styles/_variables";
+
+.merch {
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    column-gap: clamp(20px, 2.78vw, 40px);
+    row-gap: clamp(40px, 5vw, 80px);
+    margin-bottom: clamp(40px, 5vw, 80px);
+  }
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__image {
+    aspect-ratio: 1 / 1;
+    position: relative;
+    overflow: hidden;
+    background-color: $color-white;
+  }
+
+  &__img {
+    object-fit: contain;
+    transition: opacity 0.35s ease;
+    opacity: 1;
+
+    &--hidden {
+      opacity: 0;
+    }
+  }
+
+  &__like {
+    position: absolute;
+    top: 30px;
+    right: 30px;
+    z-index: 10;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    line-height: 0;
+  }
+
+  &__like-icon--inactive {
+    opacity: 0.5;
+  }
+
+  &__info {
+    margin-top: clamp(14px, 2.78vw, 40px);
+    text-align: center;
+  }
+
+  &__title,
+  &__price {
+    color: $color-ink;
+  }
+
+  &__price {
+    margin-top: 5px;
+  }
+
+  &__cta {
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/src/features/merch/components/merch.tsx
+++ b/src/features/merch/components/merch.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import Image from "next/image";
+import style from "./merch.module.scss";
+import { useState } from "react";
+import { Typography } from "@/src/components/common/typography";
+import { Button } from "@/src/components/common/button";
+import { SectionTitle } from "@/src/components/common/section-title";
+import { merchData } from "../constants";
+
+type CardProps = (typeof merchData)[number];
+
+const MerchCard = ({ frontImage, backImage, title, price }: CardProps) => {
+  const [liked, setLiked] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  const isFlipped = hovered && !!backImage;
+
+  return (
+    <div className={style["merch__card"]}>
+      <div
+        className={style["merch__image"]}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        <Image
+          src={frontImage}
+          alt={title}
+          fill
+          sizes="(max-width: 768px) 100vw, 33vw"
+          className={`${style["merch__img"]} ${isFlipped ? style["merch__img--hidden"] : ""}`}
+        />
+        {backImage && (
+          <Image
+            src={backImage}
+            alt={`${title} back`}
+            fill
+            sizes="(max-width: 768px) 100vw, 33vw"
+            className={`${style["merch__img"]} ${isFlipped ? "" : style["merch__img--hidden"]}`}
+          />
+        )}
+        {/* TODO 좋아요 기능 작업 */}
+        <button
+          type="button"
+          className={style["merch__like"]}
+          onClick={() => setLiked((prev) => !prev)}
+          aria-label={liked ? "좋아요 취소" : "좋아요"}
+        >
+          <Image
+            src={
+              liked
+                ? "/assets/icons/happy.svg"
+                : "/assets/icons/happy-black.svg"
+            }
+            alt=""
+            width={28}
+            height={28}
+            className={liked ? undefined : style["merch__like-icon--inactive"]}
+          />
+        </button>
+      </div>
+      <div className={style["merch__info"]}>
+        <Typography size="body" className={style["merch__title"]}>
+          {title}
+        </Typography>
+        <Typography size="body" weight="bold" className={style["merch__price"]}>
+          {price}
+        </Typography>
+      </div>
+    </div>
+  );
+};
+
+export const Merch = () => {
+  return (
+    <section className={style.merch}>
+      <SectionTitle>MERCH</SectionTitle>
+      <div className={style["merch__grid"]}>
+        {merchData.map((item, index) => (
+          <MerchCard key={index} {...item} />
+        ))}
+      </div>
+      <div className={style["merch__cta"]}>
+        <Button
+          variant="emoji"
+          bgColor="teal"
+          textSize="body"
+          textWeight="semibold"
+        >
+          SEE ALL MERCH
+        </Button>
+      </div>
+    </section>
+  );
+};

--- a/src/features/merch/components/merch.tsx
+++ b/src/features/merch/components/merch.tsx
@@ -7,6 +7,7 @@ import { Typography } from "@/src/components/common/typography";
 import { Button } from "@/src/components/common/button";
 import { SectionTitle } from "@/src/components/common/section-title";
 import { merchData } from "../constants";
+import { useRouter } from "next/navigation";
 
 type CardProps = (typeof merchData)[number];
 
@@ -86,6 +87,7 @@ export const Merch = () => {
           bgColor="teal"
           textSize="body"
           textWeight="semibold"
+          href="/product"
         >
           SEE ALL MERCH
         </Button>

--- a/src/features/merch/components/merch.tsx
+++ b/src/features/merch/components/merch.tsx
@@ -7,7 +7,6 @@ import { Typography } from "@/src/components/common/typography";
 import { Button } from "@/src/components/common/button";
 import { SectionTitle } from "@/src/components/common/section-title";
 import { merchData } from "../constants";
-import { useRouter } from "next/navigation";
 
 type CardProps = (typeof merchData)[number];
 

--- a/src/features/merch/constants/index.ts
+++ b/src/features/merch/constants/index.ts
@@ -1,0 +1,38 @@
+export const merchData = [
+  {
+    frontImage: "/assets/images/merch-young-hee-hood-front.png",
+    backImage: "/assets/images/merch-young-hee-hood-back.png",
+    title: "EL [심아일랜드] Young-Hee 후드티셔츠",
+    price: "49,000원",
+  },
+  {
+    frontImage: "/assets/images/merch-wwmys-hood-front.png",
+    backImage: "/assets/images/merch-wwmys-hood-back.png",
+    title: "EL [심아일랜드] We Wanna Make You Smile 후드티셔츠",
+    price: "49,000원",
+  },
+  {
+    frontImage: "/assets/images/merch-cheol-su-hood-front.png",
+    backImage: "/assets/images/merch-cheol-su-hood-back.png",
+    title: "EL [심아일랜드] Cheol-Su 후드티셔츠",
+    price: "49,000원",
+  },
+  {
+    frontImage: "/assets/images/merch-young-hee-t-shirt.png",
+    backImage: null,
+    title: "EL [심아일랜드] Young-Hee 반팔티셔츠",
+    price: "35,000원",
+  },
+  {
+    frontImage: "/assets/images/merch-cheol-su-t-shirt-b-front.png",
+    backImage: "/assets/images/merch-cheol-su-t-shirt-b-back.png",
+    title: "EL [심아일랜드] Cheol-Su 반팔티셔츠 Black",
+    price: "35,000원",
+  },
+  {
+    frontImage: "/assets/images/merch-cheol-su-t-shirt-w-front.png",
+    backImage: "/assets/images/merch-cheol-su-t-shirt-w-back.png",
+    title: "EL [심아일랜드] Cheol-Su 반팔티셔츠 White",
+    price: "35,000원",
+  },
+];

--- a/src/features/merch/index.ts
+++ b/src/features/merch/index.ts
@@ -1,0 +1,1 @@
+export * from "./components/merch";


### PR DESCRIPTION
## #️⃣ 관련 이슈

closed #5 + 그 외 하위 이슈 (closed #6 , closed #7 , closed #9)

---

## 📌 작업 내용

- 목 데이터 기반 메인 페이지 퍼블리싱

---

## ✨ 변경 사항

- Hero: GSAP + SplitType 문자별 등장 애니메이션
- Profile: ScrollTrigger 핀 스크롤 + 카드 스택 애니메이션
- Discography: 앨범 이미지 기반 동적 그라디언트 배경 주입, 3D hover 효과
- Merch: 상품 카드 앞/뒤 이미지 플립 효과, 좋아요 토글

---

## 💭 참고 / 기타

- 스케줄 섹션의 경우 디자인이 변경될 수가 있어, 아직 미구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈페이지에 히어로, 프로필, 앨범 목록, 굿즈 섹션 추가
  * 히어로: 문구별 진입 애니메이션
  * 프로필: 스크롤 연동 카드 애니메이션 및 활성 멤버 표시
  * 앨범 목록: 마우스 호버 3D 틸트 및 이미지 기반 색상 그래디언트
  * 굿즈: 이미지 앞/뒤 전환 및 좋아요 토글, 전체 목록으로 이동하는 CTA

* **수정/개선**
  * 버튼 컴포넌트: 링크(href) 전달 시 링크로 렌더링 가능

* **잡일**
  * 런타임 의존성 추가: split-type
<!-- end of auto-generated comment: release notes by coderabbit.ai -->