### PR TITLE
feat: 404(not-found) 페이지 퍼블리싱 및 Profile 컴포넌트 정리

### DIFF
--- a/src/app/(home)/profile/index.tsx
+++ b/src/app/(home)/profile/index.tsx
@@ -86,30 +86,11 @@ export const Profile = () => {
       </div>
       <div className={style["profile__info"]}>
         <Typography size="body" weight="medium">
-          {profileData[activeIndex].position.split("").map((char, i) => (
-            <span
-              key={i}
-              style={{
-                display: "inline-block",
-                whiteSpace: char === " " ? "pre" : undefined,
-              }}
-            >
-              {char}
-            </span>
-          ))}
+          <span>{profileData[activeIndex].position}</span>
         </Typography>
 
         <Typography size="heading-4" weight="bold">
-          {profileData[activeIndex].name.split("").map((char, i) => (
-            <span
-              key={i}
-              style={{
-                display: "inline-block",
-              }}
-            >
-              {char}
-            </span>
-          ))}
+          <span>{profileData[activeIndex].name}</span>
         </Typography>
       </div>
     </section>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Image from "next/image";
+import { Typography } from "../components/common/typography";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 pt-40 text-[var(--color-ink)]">
+      <Image src="/assets/icons/no.svg" alt="" width={32} height={32} />
+      <Typography as="h1" size="heading-2" weight="bold">
+        Oops!
+      </Typography>
+      <Typography size="subtitle" className="text-center">
+        해당 페이지가 없거나
+        <br />
+        링크를 잘못 입력하셨어요.
+      </Typography>
+    </div>
+  );
+}

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -9,6 +9,7 @@
     padding-left: 100px;
     padding-right: 100px;
     padding-top: 40px;
+    padding-bottom: 40px;
     position: sticky;
     top: 0;
     z-index: 100;
@@ -114,7 +115,7 @@
       }
     }
 
-    &.active {
+    &--active {
       &::before {
         display: none;
       }


### PR DESCRIPTION
## #️⃣ 관련 이슈

closed #16 

---

## 📌 작업 내용

- 404 페이지(`not-found.tsx`) 신규 퍼블리싱
- Profile 섹션 텍스트 렌더링 방식 단순화
- Header 레이아웃 하단 패딩 추가 및 SCSS 클래스명 수정

---

## ✨ 변경 사항

- `src/app/not-found.tsx` 생성 — no.svg 아이콘, "Oops!" 헤딩, 안내 문구 구성
- `src/app/(home)/profile/index.tsx` — position/name을 글자 단위 `<span>` 분리 방식에서 단일 `<span>`으로 변경
- `src/components/layout/layout.module.scss` — header `padding-bottom: 40px` 추가, `.active` → `&--active` BEM 클래스명 수정

---

## 🔍 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드 제거
- [x] 콘솔 에러 없음

---

## 💬 기타

N/A