### PR TITLE
feat: discography tracksNum 표시, 에러/빈 상태 처리, merch 카드 개선

### DIFF
--- a/src/app/discography/[albumId]/page.tsx
+++ b/src/app/discography/[albumId]/page.tsx
@@ -1,13 +1,16 @@
-import { notFound } from "next/navigation";
 import { discographyData } from "@/src/features/discography/constants";
 import { getSpotifyAlbum } from "@/src/lib/spotify";
 import { DiscographyDetail } from "./discography-detail";
+import { Empty } from "@/src/components/common/empty";
+import { FetchError } from "@/src/components/common/fetch-error";
 
-type Props = {
+type DiscographyDetailPageProps = {
   params: Promise<{ albumId: string }>;
 };
 
-export default async function DiscographyDetailPage({ params }: Props) {
+export default async function DiscographyDetailPage({
+  params,
+}: DiscographyDetailPageProps) {
   const { albumId } = await params;
 
   let album = discographyData.find((item) => item.albumId === albumId);
@@ -19,11 +22,11 @@ export default async function DiscographyDetailPage({ params }: Props) {
         (item) => item.title.toLowerCase() === spotifyAlbum.name.toLowerCase(),
       );
     } catch {
-      // Spotify 조회 실패
+      return <FetchError>앨범을 불러오는데 실패했어요.</FetchError>;
     }
   }
 
-  if (!album) notFound();
+  if (!album) return <Empty>앨범 정보가 없어요.</Empty>;
 
   return <DiscographyDetail album={album} spotifyAlbumId={albumId} />;
 }

--- a/src/app/discography/[albumId]/page.tsx
+++ b/src/app/discography/[albumId]/page.tsx
@@ -3,6 +3,7 @@ import { getSpotifyAlbum } from "@/src/lib/spotify";
 import { DiscographyDetail } from "./discography-detail";
 import { Empty } from "@/src/components/common/empty";
 import { FetchError } from "@/src/components/common/fetch-error";
+import { ApiError } from "@/src/lib/errors/api-error";
 
 type DiscographyDetailPageProps = {
   params: Promise<{ albumId: string }>;
@@ -21,7 +22,10 @@ export default async function DiscographyDetailPage({
       album = discographyData.find(
         (item) => item.title.toLowerCase() === spotifyAlbum.name.toLowerCase(),
       );
-    } catch {
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        return <Empty>앨범 정보가 없어요.</Empty>;
+      }
       return <FetchError>앨범을 불러오는데 실패했어요.</FetchError>;
     }
   }

--- a/src/app/discography/page.tsx
+++ b/src/app/discography/page.tsx
@@ -48,6 +48,7 @@ export default function DiscographyList() {
             image={album.image}
             title={album.title}
             date={album.date}
+            tracksNum={album.tracksNum}
             description={album.description}
           />
         ))}

--- a/src/features/discography/components/discography.tsx
+++ b/src/features/discography/components/discography.tsx
@@ -19,6 +19,7 @@ export const DiscographyCard = ({
   title,
   date,
   description,
+  tracksNum,
 }: DiscographyCardProps) => {
   const [gradient, setGradient] = useState<string | null>(null);
   const { imageRef, handleMouseMove, handleMouseLeave } = useAlbumCoverEffect();
@@ -62,13 +63,16 @@ export const DiscographyCard = ({
           weight="bold"
           className={style["discography__title"]}
         >
-          {artistsAlbum?.name ?? title} {trackNumber}
+          {artistsAlbum?.name ?? title}
         </Typography>
         <Typography size="body" className={style["discography__date"]}>
           {artistsAlbum?.release_date ?? date}
         </Typography>
         <Typography size="body" className={style["discography__desc"]}>
           {description}
+        </Typography>
+        <Typography size="caption">
+          Total tracks: {trackNumber ?? tracksNum}
         </Typography>
       </div>
     </Link>
@@ -88,6 +92,7 @@ export const Discography = () => {
             image={album.image}
             title={album.title}
             date={album.date}
+            tracksNum={album.tracksNum}
             description={album.description}
           />
         ))}

--- a/src/features/discography/constants/index.ts
+++ b/src/features/discography/constants/index.ts
@@ -104,6 +104,7 @@ export const discographyData: DiscographyItem[] = [
         "어쩌면 우울한 본인을 밝고 활기찬 모습으로 포장하는 걸지도.",
       ],
     ],
+    tracksNum: 5,
   },
   {
     id: "stars-and-you",
@@ -124,6 +125,7 @@ export const discographyData: DiscographyItem[] = [
         "사랑이란 무엇인지 바보라도 알겠습니다.",
       ],
     ],
+    tracksNum: 1,
   },
   {
     id: "grief-reaction",
@@ -148,6 +150,7 @@ export const discographyData: DiscographyItem[] = [
         "이 곡은 저의 아버지 故 '심재용' 님의 기일인 10월 27일에 발매되었습니다.",
       ],
     ],
+    tracksNum: 1,
   },
   {
     id: "quit-smoking",
@@ -166,6 +169,7 @@ export const discographyData: DiscographyItem[] = [
         "점점 짧아지는 담배에 미련이 남아 한모금만 더 피우고자 연신 숨을 들이키고 더이상 태울곳이 없어진 담배는 그렇게 재떨이에 파묻힌다.",
       ],
     ],
+    tracksNum: 1,
   },
   {
     id: "find-my-kid",
@@ -186,5 +190,6 @@ export const discographyData: DiscographyItem[] = [
         "아티스트 심아일은 그런 허탈한 마음을 오히려 신나는 멜로디와 편곡으로 어린 시절의 즐거움을 떠올릴 수 있도록 재해석하였다.",
       ],
     ],
+    tracksNum: 1,
   },
 ];

--- a/src/features/discography/types/index.ts
+++ b/src/features/discography/types/index.ts
@@ -8,6 +8,7 @@ export type DiscographyItem = {
   image: string;
   description: string;
   credits: string[][];
+  tracksNum?: number;
 };
 
 export type DiscographyCardProps = Omit<DiscographyItem, "credits" | "id">;

--- a/src/features/merch/components/merch.module.scss
+++ b/src/features/merch/components/merch.module.scss
@@ -23,11 +23,13 @@
 
   &__img {
     object-fit: contain;
-    transition: opacity 0.35s ease;
+    transition: all 0.5s ease;
     opacity: 1;
+    visibility: visible;
 
     &--hidden {
       opacity: 0;
+      visibility: hidden;
     }
   }
 

--- a/src/features/merch/components/merch.tsx
+++ b/src/features/merch/components/merch.tsx
@@ -8,9 +8,14 @@ import { Button } from "@/src/components/common/button";
 import { SectionTitle } from "@/src/components/common/section-title";
 import { merchData } from "../constants";
 
-type CardProps = (typeof merchData)[number];
+type MerchCardProps = (typeof merchData)[number];
 
-export const MerchCard = ({ frontImage, backImage, title, price }: CardProps) => {
+export const MerchCard = ({
+  frontImage,
+  backImage,
+  title,
+  price,
+}: MerchCardProps) => {
   const [liked, setLiked] = useState(false);
   const [hovered, setHovered] = useState(false);
 

--- a/src/lib/errors/api-error.ts
+++ b/src/lib/errors/api-error.ts
@@ -1,0 +1,12 @@
+export class ApiError extends Error {
+  status: number;
+  code?: string;
+
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+  }
+}

--- a/src/lib/spotify/_client.ts
+++ b/src/lib/spotify/_client.ts
@@ -18,9 +18,11 @@ export async function getAccessToken(): Promise<string> {
     const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
 
     if (!clientId || !clientSecret) {
-      throw new ApiError("Spotify 환경변수가 설정되지 않았습니다.", {
-        code: "MISSING_ENV",
-      });
+      throw new ApiError(
+        0,
+        "Spotify 환경변수가 설정되지 않았습니다.",
+        "MISSING_ENV",
+      );
     }
 
     const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(

--- a/src/lib/spotify/_client.ts
+++ b/src/lib/spotify/_client.ts
@@ -1,42 +1,67 @@
+import { ApiError } from "../errors/api-error";
+
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0;
 let tokenPromise: Promise<string> | null = null;
 
 export async function getAccessToken(): Promise<string> {
-  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken;
-  if (tokenPromise) return tokenPromise;
+  if (cachedToken && Date.now() < tokenExpiresAt) {
+    return cachedToken;
+  }
+
+  if (tokenPromise) {
+    return tokenPromise;
+  }
 
   tokenPromise = (async () => {
     const clientId = process.env.SPOTIFY_CLIENT_ID;
     const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
 
     if (!clientId || !clientSecret) {
-      throw new Error(
-        "SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET 환경변수가 없습니다.",
-      );
+      throw new ApiError("Spotify 환경변수가 설정되지 않았습니다.", {
+        code: "MISSING_ENV",
+      });
     }
 
     const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
       "base64",
     );
 
-    const res = await fetch("https://accounts.spotify.com/api/token", {
-      method: "POST",
-      headers: {
-        Authorization: `Basic ${credentials}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: "grant_type=client_credentials",
-    });
+    let res: Response;
 
-    if (!res.ok)
-      throw new Error(
-        `[lib/spotify/_client] Spotify 토큰 발급 실패: ${res.status}`,
+    try {
+      res = await fetch("https://accounts.spotify.com/api/token", {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${credentials}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "grant_type=client_credentials",
+      });
+    } catch {
+      throw new ApiError(
+        0,
+        "Spotify 요청 중 네트워크 오류가 발생했습니다.",
+        "NETWORK_ERROR",
       );
+    }
 
-    const data: { access_token: string; expires_in: number } = await res.json();
+    if (!res.ok) {
+      throw new ApiError(
+        res.status,
+        `Spotify 아티스트 앨범 조회 실패: ${res.status}`,
+        "SPOTIFY_ALBUM_FETCH_FAILED",
+      );
+    }
+
+    const data: {
+      access_token: string;
+      expires_in: number;
+    } = await res.json();
+
     cachedToken = data.access_token;
     tokenExpiresAt = Date.now() + (data.expires_in - 60) * 1000;
+
     return cachedToken;
   })();
 

--- a/src/lib/spotify/albums.ts
+++ b/src/lib/spotify/albums.ts
@@ -1,17 +1,30 @@
 import { SpotifyAlbum } from "@/src/types/spotify";
 import { getAccessToken } from "./_client";
+import { ApiError } from "../errors/api-error";
 
 export async function getSpotifyAlbum(albumId: string): Promise<SpotifyAlbum> {
   const token = await getAccessToken();
 
-  const res = await fetch(`https://api.spotify.com/v1/albums/${albumId}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    next: { revalidate: 3600 },
-  });
+  let res: Response;
+
+  try {
+    res = await fetch(`https://api.spotify.com/v1/albums/${albumId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      next: { revalidate: 3600 },
+    });
+  } catch {
+    throw new ApiError(
+      0,
+      "Spotify 요청 중 네트워크 오류가 발생했습니다.",
+      "NETWORK_ERROR",
+    );
+  }
 
   if (!res.ok) {
     const errorText = await res.text();
-    throw new Error(`Spotify 앨범 조회 실패: ${res.status} - ${errorText}`);
+    throw new ApiError(res.status, `Spotify 앨범 조회 실패: ${errorText}`);
   }
 
   return res.json();

--- a/src/lib/spotify/artist-albums.ts
+++ b/src/lib/spotify/artist-albums.ts
@@ -1,26 +1,34 @@
 import { SpotifyArtistAlbum } from "@/src/types/spotify";
 import { getAccessToken } from "./_client";
+import { ApiError } from "../errors/api-error";
 
 export async function getSpotifyArtistAlbums(
   artistId: string,
 ): Promise<SpotifyArtistAlbum[]> {
   const token = await getAccessToken();
 
-  const res = await fetch(
-    `https://api.spotify.com/v1/artists/${artistId}/albums`,
-    {
+  let res: Response;
+
+  try {
+    res = await fetch(`https://api.spotify.com/v1/artists/${artistId}/albums`, {
       headers: { Authorization: `Bearer ${token}` },
       next: { revalidate: 3600 },
-    },
-  );
-
-  if (!res.ok) {
-    const errorText = await res.text();
-    throw new Error(
-      `Spotify 아티스트 앨범 조회 실패: ${res.status} — ${errorText}`,
+    });
+  } catch {
+    throw new ApiError(
+      0,
+      "Spotify 요청 중 네트워크 오류가 발생했습니다.",
+      "NETWORK_ERROR",
     );
   }
 
-  const data = await res.json();
-  return data.items;
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new ApiError(
+      res.status,
+      `Spotify 아티스트 앨범 조회 실패: ${errorText}`,
+    );
+  }
+
+  return res.json();
 }

--- a/src/lib/spotify/artist-albums.ts
+++ b/src/lib/spotify/artist-albums.ts
@@ -30,5 +30,6 @@ export async function getSpotifyArtistAlbums(
     );
   }
 
-  return res.json();
+  const data: { items: SpotifyArtistAlbum[] } = await res.json();
+  return data.items;
 }

--- a/src/lib/spotify/tracks.ts
+++ b/src/lib/spotify/tracks.ts
@@ -1,17 +1,28 @@
 import { SpotifyTrack } from "@/src/types/spotify";
 import { getAccessToken } from "./_client";
+import { ApiError } from "../errors/api-error";
 
 export async function getSpotifyTrack(trackId: string): Promise<SpotifyTrack> {
   const token = await getAccessToken();
 
-  const res = await fetch(`https://api.spotify.com/v1/tracks/${trackId}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    next: { revalidate: 3600 },
-  });
+  let res: Response;
+
+  try {
+    res = await fetch(`https://api.spotify.com/v1/tracks/${trackId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      next: { revalidate: 3600 },
+    });
+  } catch {
+    throw new ApiError(
+      0,
+      "Spotify 요청 중 네트워크 오류가 발생했습니다.",
+      "NETWORK_ERROR",
+    );
+  }
 
   if (!res.ok) {
     const errorText = await res.text();
-    throw new Error(`Spotify 트랙 조회 실패: ${res.status} - ${errorText}`);
+    throw new ApiError(res.status, `Spotify 트랙 조회 실패: ${errorText}`);
   }
   return res.json();
 }


### PR DESCRIPTION
## 📌 작업 내용

- discography 카드에 트랙 수 표시
- 앨범 상세 페이지 에러/빈 상태 처리
- merch 카드 이미지 트랜지션 개선

---

## ✨변경 사항

- discography 카드에 `Total tracks` 표시 추가 (Spotify 미연결 시 상수 fallback)
- `DiscographyItem`에 `tracksNum` 옵셔널 필드 추가 및 각 앨범 데이터에 값 입력
- 앨범 상세 페이지 Spotify 조회 실패 시 `FetchError`, 앨범 없을 시 `Empty` 컴포넌트로 처리
- `MerchCard` 이미지 트랜지션 `opacity` → `all`로 변경 및 `visibility` 추가
- `CardProps` → `MerchCardProps`로 네이밍 정리

---

## 🔍 체크리스트

- [x] 정상 동작 확인
- [x] 콘솔 에러 없음

---

## 💬 기타

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 앨범 상세 페이지에서 404(앨범 없음)와 기타 불러오기 실패를 구분해 각각 적절한 사용자용 메시지로 표시

* **개선 사항**
  * 앨범 카드에 총 트랙 수를 별도 캡션으로 명확히 노출
  * Spotify 연동 오류 처리 개선으로 실패 시 사용자용 오류 안내가 더 명확해짐
  * 상품 이미지의 숨김/표시 전환이 더 부드럽고 시각적으로 일관되게 동작

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/f1m1nn2r/SIMILE-LAND/pull/28)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->