### PR TITLE
refactor: Spotify API 응답 필드명 원본 그대로 사용

### DIFF
--- a/src/app/api/spotify/album/[id]/route.ts
+++ b/src/app/api/spotify/album/[id]/route.ts
@@ -18,16 +18,16 @@ export async function GET(
     return Response.json({
       id: album.id,
       name: album.name,
-      releaseDate: album.release_date,
+      release_date: album.release_date,
       images: album.images,
-      spotifyUrl: album.external_urls.spotify,
-      artists: album.artists.map((a) => a.name),
+      external_urls: album.external_urls,
+      artists: album.artists,
       tracks: album.tracks.items.map((t) => ({
         id: t.id,
-        number: t.track_number,
+        track_number: t.track_number,
         name: t.name,
-        previewUrl: t.preview_url,
-        spotifyUrl: t.external_urls.spotify,
+        preview_url: t.preview_url,
+        external_urls: t.external_urls,
       })),
     });
   } catch (error) {

--- a/src/app/api/spotify/track/[id]/route.ts
+++ b/src/app/api/spotify/track/[id]/route.ts
@@ -16,8 +16,8 @@ export async function GET(
   try {
     const track = await getSpotifyTrack(id);
     return Response.json({
-      previewUrl: track.preview_url,
-      spotifyUrl: track.external_urls.spotify,
+      preview_url: track.preview_url,
+      external_urls: track.external_urls,
     });
   } catch (error) {
     console.error(error);

--- a/src/app/discography/[albumId]/discography-detail.tsx
+++ b/src/app/discography/[albumId]/discography-detail.tsx
@@ -86,8 +86,8 @@ export const DiscographyDetail = ({
                 track={track}
                 isCurrentlyPlaying={
                   isPlaying &&
-                  !!track.previewUrl &&
-                  currentUrl === track.previewUrl
+                  !!track.preview_url &&
+                  currentUrl === track.preview_url
                 }
                 onPlay={play}
               />

--- a/src/app/discography/[albumId]/discography-track.tsx
+++ b/src/app/discography/[albumId]/discography-track.tsx
@@ -10,10 +10,10 @@ export const DiscographyTrack = ({
   isCurrentlyPlaying,
   onPlay,
 }: DiscographyTrackItemProps) => {
-  const btnProps = track.previewUrl
-    ? { onClick: () => onPlay(track.previewUrl!) }
-    : track.spotifyUrl
-      ? { href: track.spotifyUrl }
+  const btnProps = track.preview_url
+    ? { onClick: () => onPlay(track.preview_url!) }
+    : track.external_urls?.spotify
+      ? { href: track.external_urls.spotify }
       : { onClick: () => alert("재생할 수 없어요!") };
 
   return (
@@ -23,7 +23,7 @@ export const DiscographyTrack = ({
         weight="medium"
         className={style["discography-detail__track-title"]}
       >
-        TRACK {track.number}. {track.name}
+        TRACK {track.track_number}. {track.name}
       </Typography>
       <Button
         variant="emoji"

--- a/src/features/discography/hooks/use-spotify-track.ts
+++ b/src/features/discography/hooks/use-spotify-track.ts
@@ -3,8 +3,8 @@
 import { useQuery } from "@tanstack/react-query";
 
 type SpotifyTrackResult = {
-  previewUrl: string | null;
-  spotifyUrl: string;
+  preview_url: string | null;
+  external_urls: { spotify: string };
 };
 
 async function fetchSpotifyTrack(trackId: string): Promise<SpotifyTrackResult> {

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -28,17 +28,11 @@ export type SpotifyAlbum = {
 export type SpotifyAlbumData = {
   id: string;
   name: string;
-  releaseDate: string;
+  release_date: string;
   images: { url: string; width: number; height: number }[];
-  spotifyUrl: string;
-  artists: string[];
-  tracks: {
-    id: string;
-    number: number;
-    name: string;
-    previewUrl: string | null;
-    spotifyUrl: string;
-  }[];
+  external_urls: { spotify: string };
+  artists: { id: string; name: string }[];
+  tracks: SpotifyAlbumTrack[];
 };
 
 export type SpotifyTrack = {


### PR DESCRIPTION
## 📌 작업 내용

- route handler에서 Spotify API 응답 필드명을 임의로 변환하던 것을 원본 그대로 내려주도록 통일

---

## ✨ 변경 사항

- `album/[id]` route: 
`spotifyUrl` → `external_urls`, 
`number` → `track_number`, 
`previewUrl` → `preview_url`, 
`artists` 전체 객체로 변경
- `track/[id]` route: 
`previewUrl` → `preview_url`, 
`spotifyUrl` → `external_urls`
- `SpotifyAlbumData` 타입: 
`releaseDate` → `release_date`, 
`spotifyUrl` → `external_urls`, 
`tracks` 필드 `SpotifyAlbumTrack[]` 재사용
- `use-spotify-track` 인라인 타입 동일하게 업데이트
- `discography-track`, `discography-detail` 컴포넌트 필드 참조 업데이트

---

## 🔍 체크리스트

- [x] 정상 동작 확인
- [x] 콘솔 에러 없음

---

## 💬 기타

- `artist/albums` route는 이미 원본 필드명을 사용하고 있어 변경 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Spotify API 응답 데이터 구조를 올바르게 매핑하도록 업데이트되었습니다.
  * 앨범 정보 및 트랙 미리보기 데이터 처리가 개선되었습니다.

* **리팩토링**
  * 내부 데이터 필드 이름이 Spotify 표준 형식으로 통일되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/f1m1nn2r/SIMILE-LAND/pull/29)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->